### PR TITLE
feat: openrouter free model selection

### DIFF
--- a/packages/frontend/src/components/agent/ChatInput/ModelSelector/Container.vue
+++ b/packages/frontend/src/components/agent/ChatInput/ModelSelector/Container.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
+import Button from "primevue/button";
+import Dialog from "primevue/dialog";
+import InputText from "primevue/inputtext";
 import Select from "primevue/select";
+import { ref } from "vue";
 
 import { useSelector } from "./useSelector";
 
@@ -8,78 +12,137 @@ const props = defineProps<{
   disabled?: boolean;
 }>();
 
-const { groups, modelId, selectedModel } = useSelector(props.variant);
+const { groups, modelId, selectedModel, isCustomModel } = useSelector(props.variant);
+
+const showCustomDialog = ref(false);
+const customModelInput = ref("");
+
+const openCustomDialog = () => {
+  customModelInput.value = isCustomModel.value ? modelId.value : "";
+  showCustomDialog.value = true;
+};
+
+const applyCustomModel = () => {
+  if (customModelInput.value.trim()) {
+    modelId.value = customModelInput.value.trim();
+    showCustomDialog.value = false;
+  }
+};
 </script>
 
 <template>
-  <Select
-    v-model="modelId"
-    :disabled="props.disabled === true"
-    :options="groups"
-    option-label="name"
-    option-value="id"
-    option-group-label="label"
-    option-group-children="items"
-    filter
-    filter-placeholder="Search models..."
-    :overlay-style="{
-      backgroundColor:
-        variant === 'chat' ? 'var(--p-surface-900)' : 'var(--p-surface-800)',
-      opacity: props.disabled === true ? 0.5 : 1,
-    }"
-    :pt="{
-      root: {
-        class:
-          'inline-flex relative rounded-md bg-transparent invalid:focus:ring-red-200 invalid:hover:border-red-500 transition-all duration-200 hover:border-secondary-400 cursor-pointer select-none',
-      },
-      label: {
-        class:
-          'leading-[normal] block flex-auto bg-transparent border-0 text-white/80 placeholder:text-surface-500 w-[1%] ounded-none transition duration-200 focus:outline-none focus:shadow-none relative cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap appearance-none font-mono',
-      },
-      optionGroup: { class: 'px-2' },
-      dropdownicon: { class: 'h-2 mb-0.5' },
-      header: {
-        style: {
-          background: 'none',
+  <div class="flex gap-2 items-center">
+    <Select
+      v-model="modelId"
+      :disabled="props.disabled === true"
+      :options="groups"
+      option-label="name"
+      option-value="id"
+      option-group-label="label"
+      option-group-children="items"
+      filter
+      filter-placeholder="Search models..."
+      :overlay-style="{
+        backgroundColor:
+          variant === 'chat' ? 'var(--p-surface-900)' : 'var(--p-surface-800)',
+        opacity: props.disabled === true ? 0.5 : 1,
+      }"
+      :pt="{
+        root: {
+          class:
+            'inline-flex relative rounded-md bg-transparent invalid:focus:ring-red-200 invalid:hover:border-red-500 transition-all duration-200 hover:border-secondary-400 cursor-pointer select-none',
         },
-      },
-    }"
-  >
-    <template #value>
-      <div
-        :class="[
-          'flex items-center gap-2 w-full text-surface-400 text-sm transition-colors duration-200',
-          props.disabled !== true ? 'hover:text-surface-200' : '',
-        ]"
-      >
-        <component
-          :is="selectedModel?.icon ?? undefined"
-          v-if="selectedModel?.icon !== undefined"
-          class="h-4 w-4"
-        />
-        <div v-else class="h-3 w-3 rounded-sm bg-surface-500" />
-        <span class="truncate">{{
-          selectedModel?.name ?? "Select model"
-        }}</span>
-      </div>
-    </template>
+        label: {
+          class:
+            'leading-[normal] block flex-auto bg-transparent border-0 text-white/80 placeholder:text-surface-500 w-[1%] ounded-none transition duration-200 focus:outline-none focus:shadow-none relative cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap appearance-none font-mono',
+        },
+        optionGroup: { class: 'px-2' },
+        dropdownicon: { class: 'h-2 mb-0.5' },
+        header: {
+          style: {
+            background: 'none',
+          },
+        },
+      }"
+    >
+      <template #value>
+        <div
+          :class="[
+            'flex items-center gap-2 w-full text-surface-400 text-sm transition-colors duration-200',
+            props.disabled !== true ? 'hover:text-surface-200' : '',
+          ]"
+        >
+          <component
+            :is="selectedModel?.icon ?? undefined"
+            v-if="selectedModel?.icon !== undefined"
+            class="h-4 w-4"
+          />
+          <div v-else class="h-3 w-3 rounded-sm bg-surface-500" />
+          <span class="truncate">{{
+            selectedModel?.name ?? modelId ?? "Select model"
+          }}</span>
+        </div>
+      </template>
 
-    <template #optiongroup="slotProps">
-      <div class="py-1 text-xs font-medium text-surface-400">
-        {{ slotProps.option.label }}
-      </div>
-    </template>
+      <template #optiongroup="slotProps">
+        <div class="py-1 text-xs font-medium text-surface-400">
+          {{ slotProps.option.label }}
+        </div>
+      </template>
 
-    <template #option="slotProps">
-      <div class="flex items-center gap-2 text-surface-300 text-sm">
-        <component
-          :is="slotProps.option.icon ?? undefined"
-          v-if="slotProps.option.icon !== undefined"
-          class="h-4 w-4"
+      <template #option="slotProps">
+        <div class="flex items-center gap-2 text-surface-300 text-sm">
+          <component
+            :is="slotProps.option.icon ?? undefined"
+            v-if="slotProps.option.icon !== undefined"
+            class="h-4 w-4"
+          />
+          <div v-else class="h-3 w-3 rounded-sm bg-surface-500" />
+          <span class="truncate">{{ slotProps.option.name }}</span>
+        </div>
+      </template>
+    </Select>
+
+    <Button
+      icon="fas fa-keyboard"
+      severity="secondary"
+      outlined
+      size="small"
+      :disabled="props.disabled === true"
+      v-tooltip.top="'Enter custom model ID'"
+      @click="openCustomDialog"
+    />
+
+    <Dialog
+      v-model:visible="showCustomDialog"
+      modal
+      header="Custom Model ID"
+      :style="{ width: '450px' }"
+    >
+      <div class="flex flex-col gap-3">
+        <p class="text-sm text-surface-400">
+          Enter any OpenRouter model identifier (e.g., anthropic/claude-3-opus, meta-llama/llama-3-70b)
+        </p>
+        <InputText
+          v-model="customModelInput"
+          placeholder="provider/model-name"
+          class="w-full font-mono"
+          @keydown.enter="applyCustomModel"
         />
-        <div v-else class="h-3 w-3 rounded-sm bg-surface-500" />
-        <span class="truncate">{{ slotProps.option.name }}</span>
       </div>
-    </template>
-  </Select>
+      <template #footer>
+        <Button
+          label="Cancel"
+          severity="secondary"
+          text
+          @click="showCustomDialog = false"
+        />
+        <Button
+          label="Apply"
+          :disabled="!customModelInput.trim()"
+          @click="applyCustomModel"
+        />
+      </template>
+    </Dialog>
+  </div>
 </template>

--- a/packages/frontend/src/components/agent/ChatInput/ModelSelector/useSelector.ts
+++ b/packages/frontend/src/components/agent/ChatInput/ModelSelector/useSelector.ts
@@ -69,9 +69,14 @@ export const useSelector = (variant: Variant) => {
     return item;
   });
 
+  const isCustomModel = computed<boolean>(() => {
+    return selectedModel.value === undefined && modelId.value !== "";
+  });
+
   return {
     modelId,
     groups,
     selectedModel,
+    isCustomModel,
   };
 };

--- a/packages/frontend/src/stores/config/store.ts
+++ b/packages/frontend/src/stores/config/store.ts
@@ -47,7 +47,7 @@ export const useConfigStore = defineStore("stores.config", () => {
     const model = allModels.find((item) => item.id === modelId);
 
     if (!model) {
-      return false;
+      return true;
     }
 
     if (model.onlyFor && model.onlyFor !== context) {


### PR DESCRIPTION
hey @bebiksior @Sytten

apologies if this is a dumb Q, but since the change of segregating "official plugins", i dont think i can uninstall shift to upload my new plugin package from this PR, unless i were to (easiest way) rename the local project i have and import it as a separate plugin? 🤔 but then im unsure how this would conflict in terms of the "shift+space" keyboard shortcuts etc..

tyia in advance!

<img width="1565" height="375" alt="image" src="https://github.com/user-attachments/assets/3de4df59-9131-4b7a-8f79-3d8c52367575" />

---

RE the PR, new implementation with small enhancement to enable user openrouter model selection by inputting the string, with prior functionality still intact

  - The feature is available for all three model contexts: Agents, Float, and Renaming
  - Custom models are persisted across sessions in the config store
  - Users can switch between predefined and custom models at any time
  - The input field supports pressing Enter to apply the custom model