### PR TITLE
feat: add provider-level prompt caching for cost reduction

### DIFF
--- a/packages/frontend/src/agent/agent.ts
+++ b/packages/frontend/src/agent/agent.ts
@@ -1,4 +1,4 @@
-import { stepCountIs, ToolLoopAgent } from "ai";
+import { stepCountIs, ToolLoopAgent, type SystemModelMessage } from "ai";
 import { type Model } from "shared";
 
 import type { AgentContext } from "@/agent/context";
@@ -7,20 +7,36 @@ import { shiftAgentTools } from "@/agent/tools";
 import { type FrontendSDK } from "@/types";
 import { createModel } from "@/utils/ai";
 
-function buildInstructions(context: AgentContext): string {
-  const parts: string[] = [BASE_SYSTEM_PROMPT];
+function buildInstructions(context: AgentContext): SystemModelMessage[] {
+  const messages: SystemModelMessage[] = [
+    {
+      role: "system",
+      content: BASE_SYSTEM_PROMPT,
+      providerOptions: {
+        anthropic: { cacheControl: { type: "ephemeral" } },
+        google: { cacheControl: { type: "ephemeral" } },
+        openrouter: { cacheControl: { type: "ephemeral" } },
+      },
+    },
+  ];
 
   const skillsPrompt = context.toSkillsPrompt();
   if (skillsPrompt !== "") {
-    parts.push(skillsPrompt);
+    messages.push({
+      role: "system",
+      content: skillsPrompt,
+    });
   }
 
   const contextPrompt = context.toContextPrompt();
   if (contextPrompt !== "") {
-    parts.push(contextPrompt);
+    messages.push({
+      role: "system",
+      content: contextPrompt,
+    });
   }
 
-  return parts.join("\n\n");
+  return messages;
 }
 
 type AgentOptions = {

--- a/packages/frontend/src/float/ai.ts
+++ b/packages/frontend/src/float/ai.ts
@@ -106,8 +106,21 @@ export async function queryShift(sdk: FrontendSDK, input: ActionQueryInput): Pro
       tools: floatTools,
       toolChoice: "required",
       stopWhen: stepCountIs(1),
-      system: SYSTEM_PROMPT,
-      prompt,
+      messages: [
+        {
+          role: "system",
+          content: SYSTEM_PROMPT,
+          providerOptions: {
+            anthropic: { cacheControl: { type: "ephemeral" } },
+            google: { cacheControl: { type: "ephemeral" } },
+            openrouter: { cacheControl: { type: "ephemeral" } },
+          },
+        },
+        {
+          role: "user",
+          content: prompt,
+        },
+      ],
       abortSignal: input.abortSignal,
       experimental_context: toolContext,
       experimental_repairToolCall: ({ toolCall, inputSchema, error }) =>


### PR DESCRIPTION
## Summary

- Enables prompt caching via `providerOptions` for Anthropic, Google, and OpenRouter providers
- Caches the large static system prompts (~10-15KB) so subsequent requests within the TTL window use cached reads instead of full input tokens
- Expected cost savings: **75-90% on input tokens** for cached requests

## Changes

### Float queries (`float/ai.ts`)
- Convert from `system` + `prompt` parameters to `messages` array
- Add `cacheControl: { type: "ephemeral" }` on system message for all providers

### Agent queries (`agent/agent.ts`)
- Return `SystemModelMessage[]` from `buildInstructions()` instead of string
- Cache only the static `BASE_SYSTEM_PROMPT` (~10KB)
- Dynamic context (skills, context prompt) appended as separate uncached messages

## Cost Impact

| Provider | Cache Write | Cache Read | Savings |
|----------|------------|------------|---------|
| Anthropic | 1.25x input | 0.1x input | ~90% |
| Google Gemini | input + storage | 0.25x input | ~75% |
| OpenRouter | passes through to underlying provider | | |

## Test plan

- [ ] Install plugin in Caido and test float queries
- [ ] Test agent queries with multiple turns
- [ ] Verify cache hits in provider dashboard or response metadata (`cacheCreationInputTokens` vs `cacheReadInputTokens`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)