### PR TITLE
fix: disable OpenAI reasoning hotfix

### DIFF
--- a/caido.config.ts
+++ b/caido.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   id,
   name: "Shift",
   description: "Delegate your work to Shift",
-  version: "2.3.0",
+  version: "2.3.1",
   author: {
     name: "Caido Labs Inc.",
     email: "dev@caido.io",

--- a/packages/backend/src/models/openai.ts
+++ b/packages/backend/src/models/openai.ts
@@ -1,4 +1,4 @@
-import { type Model, ModelProvider, type ModelUsageType } from "shared";
+import { type Model, ModelProvider, type ModelUsageType, supportsProviderReasoning } from "shared";
 
 const OpenAIModelIds = {
   GPT_5_4: "gpt-5.4",
@@ -7,6 +7,8 @@ const OpenAIModelIds = {
   GPT_5_3_CODEX: "gpt-5.3-codex",
 } as const;
 
+const openAIReasoningEnabled = supportsProviderReasoning(ModelProvider.OpenAI);
+
 export const openaiModels: Model[] = [
   {
     id: OpenAIModelIds.GPT_5_4,
@@ -14,7 +16,7 @@ export const openaiModels: Model[] = [
     provider: ModelProvider.OpenAI,
     contextWindow: 1_000_000,
     capabilities: {
-      reasoning: true,
+      reasoning: openAIReasoningEnabled,
     },
   },
   {
@@ -23,7 +25,7 @@ export const openaiModels: Model[] = [
     provider: ModelProvider.OpenAI,
     contextWindow: 400_000,
     capabilities: {
-      reasoning: true,
+      reasoning: openAIReasoningEnabled,
     },
   },
   {
@@ -32,7 +34,7 @@ export const openaiModels: Model[] = [
     provider: ModelProvider.OpenAI,
     contextWindow: 400_000,
     capabilities: {
-      reasoning: true,
+      reasoning: openAIReasoningEnabled,
     },
   },
   {
@@ -40,7 +42,7 @@ export const openaiModels: Model[] = [
     name: "GPT 5.3 Codex",
     provider: ModelProvider.OpenAI,
     capabilities: {
-      reasoning: true,
+      reasoning: openAIReasoningEnabled,
     },
   },
 ];

--- a/packages/backend/src/stores/models/model.ts
+++ b/packages/backend/src/stores/models/model.ts
@@ -7,6 +7,7 @@ import {
   type ModelsUserData,
   type ModelUsageType,
   type ModelUserConfig,
+  normalizeModelReasoningSupport,
 } from "shared";
 
 import {
@@ -33,7 +34,7 @@ const builtInModels: Model[] = [
   ...googleModels,
   ...openaiModels,
   ...openrouterModels,
-];
+].map(normalizeModelReasoningSupport);
 
 const defaultModelsConfig: Record<string, ModelUsageType[]> = {
   ...defaultAnthropicModelsConfig,
@@ -54,7 +55,10 @@ export function getBuiltInModelKeys(): Set<string> {
 }
 
 export function computeRuntimeConfig(userData: ModelsUserData): ModelsConfig {
-  const allModels = [...builtInModels, ...userData.customModels];
+  const allModels = [
+    ...builtInModels,
+    ...userData.customModels.map(normalizeModelReasoningSupport),
+  ];
   const config: Record<string, ModelUserConfig> = {};
 
   for (const model of allModels) {

--- a/packages/backend/src/stores/models/update.spec.ts
+++ b/packages/backend/src/stores/models/update.spec.ts
@@ -77,6 +77,22 @@ describe("models update", () => {
       expect(result.customModels).toHaveLength(0);
       expect(result).toBe(model);
     });
+
+    it("disables reasoning for new openai custom models", () => {
+      const model = createInitialModel();
+
+      const result = update(model, {
+        type: "ADD_MODEL",
+        model: {
+          id: "custom-model-2",
+          name: "Custom Model 2",
+          provider: "openai",
+          capabilities: { reasoning: true },
+        },
+      });
+
+      expect(result.customModels[0]?.capabilities.reasoning).toBe(false);
+    });
   });
 
   describe("REMOVE_MODEL", () => {
@@ -238,6 +254,15 @@ describe("models update", () => {
 
       expect(overriddenRuntime.config[key]?.enabled).toBe(false);
       expect(overriddenRuntime.config[key]?.enabledFor).toEqual([]);
+    });
+
+    it("disables reasoning for openai models in runtime config", () => {
+      const runtime = computeRuntimeConfig(createTestModel());
+      const customModel = runtime.models.find((model) => model.id === "custom-model-1");
+      const builtInOpenAIModel = runtime.models.find((model) => model.provider === "openai");
+
+      expect(customModel?.capabilities.reasoning).toBe(false);
+      expect(builtInOpenAIModel?.capabilities.reasoning).toBe(false);
     });
   });
 });

--- a/packages/backend/src/stores/models/update.ts
+++ b/packages/backend/src/stores/models/update.ts
@@ -1,5 +1,5 @@
 import { create } from "mutative";
-import { createModelKey } from "shared";
+import { createModelKey, normalizeModelReasoningSupport } from "shared";
 
 import { getBuiltInModelKeys, type ModelsMessage, type ModelsModel } from "./model";
 
@@ -7,7 +7,8 @@ function handleAddModel(
   model: ModelsModel,
   message: Extract<ModelsMessage, { type: "ADD_MODEL" }>
 ): ModelsModel {
-  const key = createModelKey(message.model.provider, message.model.id);
+  const normalizedModel = normalizeModelReasoningSupport(message.model);
+  const key = createModelKey(normalizedModel.provider, normalizedModel.id);
   const builtInKeys = getBuiltInModelKeys();
 
   if (builtInKeys.has(key)) {
@@ -21,7 +22,7 @@ function handleAddModel(
   }
 
   return create(model, (draft) => {
-    draft.customModels.push(message.model);
+    draft.customModels.push(normalizedModel);
     draft.configOverrides[key] = {
       enabled: true,
       enabledFor: ["agent", "float"],

--- a/packages/frontend/src/components/agent/ChatInput/ModelSelector/Container.vue
+++ b/packages/frontend/src/components/agent/ChatInput/ModelSelector/Container.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { onClickOutside } from "@vueuse/core";
-import type { Model } from "shared";
+import { getProviderReasoningDisabledMessage, type Model } from "shared";
 import { ref } from "vue";
 
 import { useModelSelector } from "./useModelSelector";
@@ -38,6 +38,7 @@ const {
   activeReasoningModel,
   shouldShowEffortStep,
   selectedModelLabel,
+  supportsReasoning,
   reasoningEfforts,
   effortConfig,
   reasoningEffort,
@@ -126,7 +127,15 @@ onClickOutside(containerRef, close);
                       : 'text-surface-400 hover:bg-surface-800 hover:text-surface-200',
                 ]"
                 @click="handleProviderClick(provider)">
-                <span class="truncate">{{ getProviderDisplayName(provider.id) }}</span>
+                <div class="flex min-w-0 items-center gap-1">
+                  <span class="truncate">{{ getProviderDisplayName(provider.id) }}</span>
+                  <span
+                    v-if="getProviderReasoningDisabledMessage(provider.id) !== undefined"
+                    v-tooltip.right="getProviderReasoningDisabledMessage(provider.id)"
+                    class="inline-flex h-4 w-4 shrink-0 cursor-help items-center justify-center text-surface-400 opacity-80">
+                    <i class="fas fa-exclamation-triangle text-[10px]" />
+                  </span>
+                </div>
                 <i
                   v-if="!provider.isConfigured"
                   class="fas fa-exclamation-circle text-[10px] text-surface-600" />
@@ -172,7 +181,7 @@ onClickOutside(containerRef, close);
                       v-if="!model.isConfigured"
                       class="fas fa-exclamation-circle text-[10px] text-surface-500" />
                     <div
-                      v-else-if="usesReasoningVariants && model.capabilities.reasoning"
+                      v-else-if="usesReasoningVariants && supportsReasoning(model)"
                       class="flex items-center gap-1.5 shrink-0">
                       <i
                         v-if="model.id === selectedModel?.id"

--- a/packages/frontend/src/components/agent/ChatInput/ModelSelector/useModelSelector.ts
+++ b/packages/frontend/src/components/agent/ChatInput/ModelSelector/useModelSelector.ts
@@ -1,4 +1,4 @@
-import type { Model } from "shared";
+import { type Model, supportsProviderReasoning } from "shared";
 import { computed, type MaybeRefOrGetter, nextTick, type Ref, ref, toValue, watch } from "vue";
 
 import { type ProviderInfo, useSelector } from "./useSelector";
@@ -55,20 +55,27 @@ export function useModelSelector(options: UseModelSelectorOptions) {
 
   const usesReasoningVariants = computed(() => toValue(options.reasoningMode) === "variant");
   const isDisabled = computed(() => toValue(options.disabled));
+  const supportsReasoning = (model: Model | undefined): boolean => {
+    return (
+      model !== undefined &&
+      model.capabilities.reasoning &&
+      supportsProviderReasoning(model.provider)
+    );
+  };
 
   const activeReasoningModel = computed(() => {
     if (activeReasoningModelId.value === undefined) return undefined;
     return providerModels.value.find((model) => model.id === activeReasoningModelId.value);
   });
 
-  const shouldShowEffortStep = computed(
-    () => usesReasoningVariants.value && activeReasoningModel.value?.capabilities.reasoning === true
-  );
+  const shouldShowEffortStep = computed(() => {
+    return usesReasoningVariants.value && supportsReasoning(activeReasoningModel.value);
+  });
 
   const selectedModelLabel = computed(() => {
     const model = options.selectedModel.value;
     if (model === undefined) return "Select model";
-    if (!usesReasoningVariants.value || model.capabilities.reasoning !== true) {
+    if (!usesReasoningVariants.value || !supportsReasoning(model)) {
       return model.name;
     }
     return `${model.name} ${effortConfig[reasoningEffort.value].label}`;
@@ -92,7 +99,7 @@ export function useModelSelector(options: UseModelSelectorOptions) {
     if (
       usesReasoningVariants.value &&
       model !== undefined &&
-      model.capabilities.reasoning &&
+      supportsReasoning(model) &&
       model.provider === activeProvider.value
     ) {
       activeReasoningModelId.value = model.id;
@@ -101,7 +108,7 @@ export function useModelSelector(options: UseModelSelectorOptions) {
 
   const handleSelect = (model: ModelWithConfig) => {
     if (!model.isConfigured) return;
-    if (usesReasoningVariants.value && model.capabilities.reasoning) {
+    if (usesReasoningVariants.value && supportsReasoning(model)) {
       activeReasoningModelId.value = model.id;
       return;
     }
@@ -117,7 +124,7 @@ export function useModelSelector(options: UseModelSelectorOptions) {
   const handleEffortSelect = (effort: ReasoningEffort) => {
     if (!usesReasoningVariants.value) return;
     const model = activeReasoningModel.value;
-    if (model === undefined || !model.isConfigured || !model.capabilities.reasoning) return;
+    if (model === undefined || !model.isConfigured || !supportsReasoning(model)) return;
     reasoningEffort.value = effort;
     options.selectedModel.value = model;
     close();
@@ -152,6 +159,7 @@ export function useModelSelector(options: UseModelSelectorOptions) {
     activeReasoningModel,
     shouldShowEffortStep,
     selectedModelLabel,
+    supportsReasoning,
     reasoningEfforts,
     effortConfig,
     reasoningEffort,

--- a/packages/frontend/src/components/models/AddModelDialog/Container.vue
+++ b/packages/frontend/src/components/models/AddModelDialog/Container.vue
@@ -4,8 +4,13 @@ import Checkbox from "primevue/checkbox";
 import Dialog from "primevue/dialog";
 import Dropdown from "primevue/dropdown";
 import InputText from "primevue/inputtext";
-import { type Model, ModelProvider, type ModelProvider as ModelProviderType } from "shared";
-import { ref, watch } from "vue";
+import {
+  getProviderReasoningDisabledMessage,
+  type Model,
+  ModelProvider,
+  type ModelProvider as ModelProviderType,
+} from "shared";
+import { computed, ref, watch } from "vue";
 
 const { initialProvider } = defineProps<{
   initialProvider: ModelProviderType;
@@ -26,6 +31,9 @@ const name = ref("");
 const id = ref("");
 const isReasoningModel = ref(false);
 const provider = ref<ModelProviderType>(initialProvider);
+const providerReasoningDisabledMessage = computed(() => {
+  return getProviderReasoningDisabledMessage(provider.value);
+});
 
 const canSave = () => name.value.trim() !== "" && id.value.trim() !== "";
 
@@ -42,6 +50,12 @@ watch(visible, (isVisible) => {
   }
 });
 
+watch(provider, (nextProvider) => {
+  if (getProviderReasoningDisabledMessage(nextProvider) !== undefined) {
+    isReasoningModel.value = false;
+  }
+});
+
 const handleSave = () => {
   if (!canSave()) return;
 
@@ -50,7 +64,7 @@ const handleSave = () => {
     id: id.value.trim(),
     provider: provider.value,
     capabilities: {
-      reasoning: isReasoningModel.value,
+      reasoning: providerReasoningDisabledMessage.value === undefined && isReasoningModel.value,
     },
   });
 
@@ -111,10 +125,13 @@ const handleCancel = () => {
         <Checkbox
           v-model="isReasoningModel"
           binary
+          :disabled="providerReasoningDisabledMessage !== undefined"
           input-id="reasoning" />
         <label
           for="reasoning"
-          class="text-surface-200">
+          :class="
+            providerReasoningDisabledMessage === undefined ? 'text-surface-200' : 'text-surface-500'
+          ">
           Is Reasoning Model
         </label>
       </div>

--- a/packages/frontend/src/stores/models/store.update.spec.ts
+++ b/packages/frontend/src/stores/models/store.update.spec.ts
@@ -40,7 +40,9 @@ describe("models update", () => {
       const result = update(loadingModel, { type: "FETCH_SUCCESS", config: config! });
 
       expect(result.isLoading).toBe(false);
-      expect(result.config).toEqual(config);
+      expect(result.config?.models[0]?.capabilities.reasoning).toBe(false);
+      expect(result.config?.config).toEqual(config?.config);
+      expect(result.config?.customModelKeys).toEqual(config?.customModelKeys);
       expect(result.error).toBeUndefined();
     });
   });
@@ -112,6 +114,23 @@ describe("models update", () => {
       });
 
       expect(result).toBe(initialModel);
+    });
+
+    it("disables reasoning for openai models", () => {
+      const config = createTestConfig();
+      const modelWithConfig: ModelsModel = { ...initialModel, config };
+
+      const result = update(modelWithConfig, {
+        type: "ADD_MODEL_SUCCESS",
+        input: {
+          id: "custom-openai",
+          name: "Custom OpenAI",
+          provider: "openai",
+          capabilities: { reasoning: true },
+        },
+      });
+
+      expect(result.config?.models[1]?.capabilities.reasoning).toBe(false);
     });
   });
 

--- a/packages/frontend/src/stores/models/store.update.ts
+++ b/packages/frontend/src/stores/models/store.update.ts
@@ -4,6 +4,7 @@ import {
   createModelKey,
   type ModelsConfig,
   type ModelUsageType,
+  normalizeModelReasoningSupport,
   type RemoveModelInput,
   type UpdateModelConfigInput,
 } from "shared";
@@ -20,7 +21,10 @@ function handleFetchRequest(model: ModelsModel): ModelsModel {
 function handleFetchSuccess(model: ModelsModel, config: ModelsConfig): ModelsModel {
   return create(model, (draft) => {
     draft.isLoading = false;
-    draft.config = config;
+    draft.config = {
+      ...config,
+      models: config.models.map(normalizeModelReasoningSupport),
+    };
     draft.error = undefined;
   });
 }
@@ -37,7 +41,8 @@ function handleAddModelSuccess(model: ModelsModel, input: AddModelInput): Models
     return model;
   }
 
-  const key = createModelKey(input.provider, input.id);
+  const normalizedInput = normalizeModelReasoningSupport(input);
+  const key = createModelKey(normalizedInput.provider, normalizedInput.id);
   const exists = model.config.models.some((m) => createModelKey(m.provider, m.id) === key);
 
   if (exists) {
@@ -46,7 +51,7 @@ function handleAddModelSuccess(model: ModelsModel, input: AddModelInput): Models
 
   return create(model, (draft) => {
     if (draft.config === undefined) return;
-    draft.config.models.push(input);
+    draft.config.models.push(normalizedInput);
     draft.config.config[key] = {
       modelKey: key,
       enabled: true,

--- a/packages/frontend/src/utils/ai.ts
+++ b/packages/frontend/src/utils/ai.ts
@@ -5,6 +5,7 @@ import {
   type Model,
   ModelProvider,
   type ModelProvider as ModelProviderId,
+  supportsProviderReasoning,
 } from "shared";
 
 import type { FrontendSDK } from "../types";
@@ -58,7 +59,10 @@ export function createModel(sdk: FrontendSDK, model: Model, options: CreateModel
     openRouterPrioritizeFastProviders = false,
   } = options;
 
-  const isReasoningModel = reasoning && (model?.capabilities.reasoning ?? false);
+  const isReasoningModel =
+    reasoning &&
+    (model?.capabilities.reasoning ?? false) &&
+    supportsProviderReasoning(model.provider);
 
   const provider = sdk.ai.createProvider();
 

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -27,6 +27,35 @@ const ModelSchema = z.object({
 });
 export type Model = z.infer<typeof ModelSchema>;
 
+export const PROVIDER_REASONING_DISABLED_MESSAGES: Partial<Record<ModelProvider, string>> = {
+  [ModelProvider.OpenAI]: "Reasoning is temporarily unavailable for this provider.",
+};
+
+export const getProviderReasoningDisabledMessage = (
+  provider: ModelProvider
+): string | undefined => {
+  return PROVIDER_REASONING_DISABLED_MESSAGES[provider];
+};
+
+export const supportsProviderReasoning = (provider: ModelProvider): boolean => {
+  return getProviderReasoningDisabledMessage(provider) === undefined;
+};
+
+export const normalizeModelReasoningSupport = (model: Model): Model => {
+  const reasoning = model.capabilities.reasoning && supportsProviderReasoning(model.provider);
+  if (reasoning === model.capabilities.reasoning) {
+    return model;
+  }
+
+  return {
+    ...model,
+    capabilities: {
+      ...model.capabilities,
+      reasoning,
+    },
+  };
+};
+
 const ModelUsageTypeSchema = z.enum(["agent", "float"]);
 export type ModelUsageType = z.infer<typeof ModelUsageTypeSchema>;
 


### PR DESCRIPTION
Temporarily disable reasoning support for the OpenAI provider. Adds a warning inside the model chooser popup.
Also bumps version to 2.3.1