### PR TITLE
feat: add AWS Bedrock provider support

### DIFF
--- a/packages/backend/src/models/bedrock.ts
+++ b/packages/backend/src/models/bedrock.ts
@@ -1,0 +1,54 @@
+import { type Model, ModelProvider, type ModelUsageType } from "shared";
+
+const BedrockModelIds = {
+  CLAUDE_SONNET_4_5: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+  CLAUDE_HAIKU_4_5: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  NOVA_PRO: "us.amazon.nova-pro-v1:0",
+  NOVA_LITE: "us.amazon.nova-lite-v1:0",
+} as const;
+
+export const bedrockModels: Model[] = [
+  {
+    id: BedrockModelIds.CLAUDE_SONNET_4_5,
+    name: "Claude Sonnet 4.5 (Bedrock)",
+    provider: ModelProvider.Bedrock,
+    contextWindow: 200_000,
+    capabilities: {
+      reasoning: false,
+    },
+  },
+  {
+    id: BedrockModelIds.CLAUDE_HAIKU_4_5,
+    name: "Claude Haiku 4.5 (Bedrock)",
+    provider: ModelProvider.Bedrock,
+    contextWindow: 200_000,
+    capabilities: {
+      reasoning: false,
+    },
+  },
+  {
+    id: BedrockModelIds.NOVA_PRO,
+    name: "Amazon Nova Pro (Bedrock)",
+    provider: ModelProvider.Bedrock,
+    contextWindow: 300_000,
+    capabilities: {
+      reasoning: false,
+    },
+  },
+  {
+    id: BedrockModelIds.NOVA_LITE,
+    name: "Amazon Nova Lite (Bedrock)",
+    provider: ModelProvider.Bedrock,
+    contextWindow: 300_000,
+    capabilities: {
+      reasoning: false,
+    },
+  },
+];
+
+export const defaultBedrockModelsConfig: Record<string, ModelUsageType[]> = {
+  [BedrockModelIds.CLAUDE_SONNET_4_5]: ["agent", "float"],
+  [BedrockModelIds.CLAUDE_HAIKU_4_5]: ["agent", "float"],
+  [BedrockModelIds.NOVA_PRO]: ["agent", "float"],
+  [BedrockModelIds.NOVA_LITE]: ["agent", "float"],
+};

--- a/packages/backend/src/models/index.ts
+++ b/packages/backend/src/models/index.ts
@@ -1,4 +1,5 @@
 export * from "./anthropic";
+export * from "./bedrock";
 export * from "./google";
 export * from "./openai";
 export * from "./openrouter";

--- a/packages/backend/src/stores/models/model.ts
+++ b/packages/backend/src/stores/models/model.ts
@@ -12,7 +12,9 @@ import {
 
 import {
   anthropicModels,
+  bedrockModels,
   defaultAnthropicModelsConfig,
+  defaultBedrockModelsConfig,
   defaultGoogleModelsConfig,
   defaultOpenAIModelsConfig,
   defaultOpenRouterModelsConfig,
@@ -31,6 +33,7 @@ export type ModelsMessage =
 
 const builtInModels: Model[] = [
   ...anthropicModels,
+  ...bedrockModels,
   ...googleModels,
   ...openaiModels,
   ...openrouterModels,
@@ -38,6 +41,7 @@ const builtInModels: Model[] = [
 
 const defaultModelsConfig: Record<string, ModelUsageType[]> = {
   ...defaultAnthropicModelsConfig,
+  ...defaultBedrockModelsConfig,
   ...defaultGoogleModelsConfig,
   ...defaultOpenAIModelsConfig,
   ...defaultOpenRouterModelsConfig,

--- a/packages/backend/src/stores/settings/update.ts
+++ b/packages/backend/src/stores/settings/update.ts
@@ -33,6 +33,9 @@ function handleUpdateSettings(
     if (input.featureFlags !== undefined) {
       draft.featureFlags = { ...draft.featureFlags, ...input.featureFlags };
     }
+    if (input.bedrockCredentials !== undefined) {
+      draft.bedrockCredentials = input.bedrockCredentials ?? undefined;
+    }
   });
 }
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -6,6 +6,7 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {
+    "@ai-sdk/amazon-bedrock": "4.0.97",
     "@ai-sdk/provider": "3.0.8",
     "@ai-sdk/vue": "3.0.116",
     "@caido/primevue": "0.3.3",

--- a/packages/frontend/src/components/agent/ChatInput/ModelSelector/useSelector.ts
+++ b/packages/frontend/src/components/agent/ChatInput/ModelSelector/useSelector.ts
@@ -9,13 +9,14 @@ export type ProviderInfo = {
   isConfigured: boolean;
 };
 
-const PROVIDER_ORDER: ModelProvider[] = ["openrouter", "anthropic", "google", "openai"];
+const PROVIDER_ORDER: ModelProvider[] = ["openrouter", "anthropic", "google", "openai", "bedrock"];
 
 const PROVIDER_DISPLAY_NAMES: Record<ModelProvider, string> = {
   openrouter: "OpenRouter",
   anthropic: "Anthropic",
   google: "Google",
   openai: "OpenAI",
+  bedrock: "AWS Bedrock",
 };
 
 export const getProviderDisplayName = (provider: ModelProvider): string => {

--- a/packages/frontend/src/components/settings/Container.vue
+++ b/packages/frontend/src/components/settings/Container.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
+import Button from "primevue/button";
 import Card from "primevue/card";
 import Checkbox from "primevue/checkbox";
 import InputNumber from "primevue/inputnumber";
+import InputText from "primevue/inputtext";
 import ToggleSwitch from "primevue/toggleswitch";
 import { DEFAULT_MAX_ITERATIONS, defaultFeatureFlags, type FeatureFlagKey } from "shared";
-import { computed } from "vue";
+import { computed, ref, watch } from "vue";
 
 import { featureFlagEntries } from "@/features";
 import { useSettingsStore } from "@/stores/settings";
@@ -62,6 +64,46 @@ const updateFeatureFlag = (flag: FeatureFlagKey, value: boolean) => {
     featureFlags: { [flag]: value },
   });
 };
+
+const bedrockAccessKeyId = ref(settingsStore.bedrockCredentials?.accessKeyId ?? "");
+const bedrockSecretAccessKey = ref(settingsStore.bedrockCredentials?.secretAccessKey ?? "");
+const bedrockRegion = ref(settingsStore.bedrockCredentials?.region ?? "");
+
+watch(
+  () => settingsStore.bedrockCredentials,
+  (creds) => {
+    bedrockAccessKeyId.value = creds?.accessKeyId ?? "";
+    bedrockSecretAccessKey.value = creds?.secretAccessKey ?? "";
+    bedrockRegion.value = creds?.region ?? "";
+  }
+);
+
+const bedrockIsConfigured = computed(() => {
+  const creds = settingsStore.bedrockCredentials;
+  return (
+    creds !== undefined &&
+    creds.accessKeyId !== "" &&
+    creds.secretAccessKey !== "" &&
+    creds.region !== ""
+  );
+});
+
+function saveBedrockCredentials() {
+  const accessKeyId = bedrockAccessKeyId.value.trim();
+  const secretAccessKey = bedrockSecretAccessKey.value.trim();
+  const region = bedrockRegion.value.trim();
+  if (!accessKeyId || !secretAccessKey || !region) return;
+  updateSettings(sdk, dispatch, {
+    bedrockCredentials: { accessKeyId, secretAccessKey, region },
+  });
+}
+
+function clearBedrockCredentials() {
+  bedrockAccessKeyId.value = "";
+  bedrockSecretAccessKey.value = "";
+  bedrockRegion.value = "";
+  updateSettings(sdk, dispatch, { bedrockCredentials: null });
+}
 </script>
 
 <template>
@@ -129,6 +171,49 @@ const updateFeatureFlag = (flag: FeatureFlagKey, value: boolean) => {
             </div>
 
             <ToggleSwitch v-model="openRouterPrioritizeFastProviders" />
+          </div>
+
+          <div class="flex flex-col gap-3">
+            <div class="flex items-center justify-between">
+              <div class="flex flex-col">
+                <label class="text-base font-medium">AWS Bedrock</label>
+                <p class="text-sm text-surface-400">
+                  Configure AWS credentials to use Bedrock-hosted models.
+                </p>
+              </div>
+              <span
+                :class="bedrockIsConfigured ? 'text-green-400' : 'text-surface-400'"
+                class="text-xs font-medium">
+                {{ bedrockIsConfigured ? "Configured" : "Not configured" }}
+              </span>
+            </div>
+
+            <div class="flex flex-col gap-2">
+              <InputText
+                v-model="bedrockAccessKeyId"
+                placeholder="Access Key ID"
+                class="w-full"
+                @blur="saveBedrockCredentials" />
+              <InputText
+                v-model="bedrockSecretAccessKey"
+                type="password"
+                placeholder="Secret Access Key"
+                class="w-full"
+                @blur="saveBedrockCredentials" />
+              <InputText
+                v-model="bedrockRegion"
+                placeholder="Region (e.g. us-east-1)"
+                class="w-full"
+                @blur="saveBedrockCredentials" />
+              <div class="flex justify-end">
+                <Button
+                  v-if="bedrockIsConfigured"
+                  label="Clear credentials"
+                  severity="secondary"
+                  size="small"
+                  @click="clearBedrockCredentials" />
+              </div>
+            </div>
           </div>
 
           <div class="flex flex-col gap-3">

--- a/packages/frontend/src/stores/settings/store.ts
+++ b/packages/frontend/src/stores/settings/store.ts
@@ -34,6 +34,7 @@ export const useSettingsStore = defineStore("settings", () => {
   const backgroundAgentsEnabled = computed(() =>
     isFeatureFlagEnabled(model.value.config?.featureFlags, "backgroundAgents")
   );
+  const bedrockCredentials = computed(() => model.value.config?.bedrockCredentials);
 
   async function initialize() {
     await fetchSettings(sdk, dispatch);
@@ -60,6 +61,7 @@ export const useSettingsStore = defineStore("settings", () => {
     openRouterPrioritizeFastProviders,
     featureFlags,
     backgroundAgentsEnabled,
+    bedrockCredentials,
     isFeatureEnabled,
     initialize,
   };

--- a/packages/frontend/src/stores/settings/store.update.ts
+++ b/packages/frontend/src/stores/settings/store.update.ts
@@ -63,6 +63,9 @@ function handleUpdateSuccess(model: SettingsModel, input: UpdateSettingsInput): 
         ...input.featureFlags,
       };
     }
+    if (input.bedrockCredentials !== undefined) {
+      draft.config.bedrockCredentials = input.bedrockCredentials ?? undefined;
+    }
   });
 }
 

--- a/packages/frontend/src/utils/ai.ts
+++ b/packages/frontend/src/utils/ai.ts
@@ -1,5 +1,5 @@
+import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
 import { type LanguageModelV3 } from "@ai-sdk/provider";
-import { type AIUpstreamProviderId } from "@caido/sdk-frontend";
 import {
   createModelKey,
   type Model,
@@ -12,22 +12,39 @@ import type { FrontendSDK } from "../types";
 
 import { isPresent } from "./optional";
 
+import { useSettingsStore } from "@/stores/settings";
+
 type ProviderStatus = {
-  id: AIUpstreamProviderId;
+  id: string;
   isConfigured: boolean;
 };
 
+function isBedrockConfigured(): boolean {
+  const settingsStore = useSettingsStore();
+  const creds = settingsStore.bedrockCredentials;
+  return (
+    creds !== undefined &&
+    creds.accessKeyId !== "" &&
+    creds.secretAccessKey !== "" &&
+    creds.region !== ""
+  );
+}
+
 export function getProviderStatuses(sdk: FrontendSDK): ProviderStatus[] {
-  return sdk.ai.getUpstreamProviders().map((provider) => ({
+  const caidoStatuses = sdk.ai.getUpstreamProviders().map((provider) => ({
     id: provider.id,
     isConfigured: provider.status === "Ready",
   }));
+  return [...caidoStatuses, { id: ModelProvider.Bedrock, isConfigured: isBedrockConfigured() }];
 }
 
 export function isProviderConfigured(sdk: FrontendSDK, provider: ModelProviderId): boolean {
-  const statuses = getProviderStatuses(sdk);
+  if (provider === ModelProvider.Bedrock) {
+    return isBedrockConfigured();
+  }
+  const statuses = sdk.ai.getUpstreamProviders();
   const status = statuses.find((s) => s.id === provider);
-  return status?.isConfigured ?? false;
+  return status?.status === "Ready";
 }
 
 export function isAnyProviderConfigured(sdk: FrontendSDK): boolean {
@@ -37,7 +54,11 @@ export function isAnyProviderConfigured(sdk: FrontendSDK): boolean {
 
 export class ProviderNotConfiguredError extends Error {
   constructor(provider: ModelProviderId) {
-    super(`Provider "${provider}" is not configured. Please configure it in Caido AI settings.`);
+    const hint =
+      provider === ModelProvider.Bedrock
+        ? "Please add your AWS credentials in Shift settings."
+        : "Please configure it in Caido AI settings.";
+    super(`Provider "${provider}" is not configured. ${hint}`);
     this.name = "ProviderNotConfiguredError";
   }
 }
@@ -63,6 +84,25 @@ export function createModel(sdk: FrontendSDK, model: Model, options: CreateModel
     reasoning &&
     (model?.capabilities.reasoning ?? false) &&
     supportsProviderReasoning(model.provider);
+
+  if (model.provider === ModelProvider.Bedrock) {
+    const settingsStore = useSettingsStore();
+    const creds = settingsStore.bedrockCredentials;
+    if (
+      creds === undefined ||
+      creds.accessKeyId === "" ||
+      creds.secretAccessKey === "" ||
+      creds.region === ""
+    ) {
+      throw new ProviderNotConfiguredError(model.provider);
+    }
+    const bedrock = createAmazonBedrock({
+      region: creds.region,
+      accessKeyId: creds.accessKeyId,
+      secretAccessKey: creds.secretAccessKey,
+    });
+    return bedrock(model.id) as unknown as LanguageModelV3;
+  }
 
   const provider = sdk.ai.createProvider();
 

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -1,4 +1,3 @@
-import { type AIUpstreamProviderId } from "@caido/sdk-frontend";
 import { z } from "zod";
 
 import { isPresent } from "../../frontend/src/utils/optional";
@@ -8,7 +7,8 @@ export const ModelProvider = {
   OpenAI: "openai",
   Anthropic: "anthropic",
   Google: "google",
-} as const satisfies Record<string, AIUpstreamProviderId>;
+  Bedrock: "bedrock",
+} as const;
 
 export type ModelProvider = (typeof ModelProvider)[keyof typeof ModelProvider];
 const ModelProviderSchema = z.nativeEnum(ModelProvider);

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -9,6 +9,13 @@ const RenamingConfigSchema = z.object({
 });
 export type RenamingConfig = z.infer<typeof RenamingConfigSchema>;
 
+export const BedrockCredentialsSchema = z.object({
+  accessKeyId: z.string(),
+  secretAccessKey: z.string(),
+  region: z.string(),
+});
+export type BedrockCredentials = z.infer<typeof BedrockCredentialsSchema>;
+
 const SettingsConfigSchema = z.object({
   agentsModel: z.string(),
   floatModel: z.string(),
@@ -19,6 +26,7 @@ const SettingsConfigSchema = z.object({
   autoCreateShiftCollection: z.boolean(),
   openRouterPrioritizeFastProviders: z.boolean(),
   featureFlags: FeatureFlagsConfigSchema,
+  bedrockCredentials: BedrockCredentialsSchema.optional(),
 });
 export type SettingsConfig = z.infer<typeof SettingsConfigSchema>;
 
@@ -41,6 +49,7 @@ export const defaultSettingsConfig: SettingsConfig = {
   autoCreateShiftCollection: true,
   openRouterPrioritizeFastProviders: false,
   featureFlags: defaultFeatureFlags,
+  bedrockCredentials: undefined,
 };
 
 export const UpdateSettingsSchema = z.object({
@@ -53,5 +62,6 @@ export const UpdateSettingsSchema = z.object({
   autoCreateShiftCollection: z.boolean().optional(),
   openRouterPrioritizeFastProviders: z.boolean().optional(),
   featureFlags: FeatureFlagsConfigSchema.partial().optional(),
+  bedrockCredentials: BedrockCredentialsSchema.nullable().optional(),
 });
 export type UpdateSettingsInput = z.infer<typeof UpdateSettingsSchema>;


### PR DESCRIPTION
This is my first contribution like this, but I've found this integration to be very useful for my workflow. This feature adds AWS Bedrock as a model provider with 4 built-in models (Claude Sonnet 4.5, Haiku 4.5, Nova Pro, Nova Lite). Credentials are stored in plugin settings and configured via a new AWS Bedrock section in the settings UI.