### PR TITLE
More fixes for new Caido release

### DIFF
--- a/caido.config.ts
+++ b/caido.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   id,
   name: "Shift",
   description: "Delegate your work to Shift",
-  version: "2.3.3",
+  version: "2.3.4",
   author: {
     name: "Caido Labs Inc.",
     email: "dev@caido.io",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@caido/sdk-backend": "0.57.0",
-    "@caido/sdk-frontend": "0.57.1-beta.4",
+    "@caido/sdk-frontend": "0.56.3-beta.2",
     "@codemirror/view": "6.39.16",
     "vue-tsc": "3.2.5"
   }

--- a/packages/frontend/src/agent/tools/replay/ReplayEntryNavigate.ts
+++ b/packages/frontend/src/agent/tools/replay/ReplayEntryNavigate.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 import type { AgentContext } from "@/agent/context";
 import { type ToolDisplay, ToolResult, type ToolResult as ToolResultType } from "@/agent/types";
-import { getReplayEntryRequest } from "@/utils/caido";
+import { decodeBlob, getReplayEntryRequest } from "@/utils/caido";
 
 const inputSchema = z.object({
   entryId: z
@@ -58,15 +58,16 @@ export const ReplayEntryNavigate = tool({
         return ToolResult.err("Entry does not belong to the current session");
       }
 
-      await sdk.replay.showEntry(context.sessionId, entryId);
+      const decodedRaw = decodeBlob(entry.raw);
 
-      context.setHttpRequest(entry.raw);
+      await sdk.replay.showEntry(context.sessionId, entryId);
+      context.setHttpRequest(decodedRaw);
 
       return ToolResult.ok({
         message: `Navigated to entry ${entryId}`,
         entryId,
         requestId: request?.id,
-        requestRaw: entry.raw,
+        requestRaw: decodedRaw,
       });
     } catch (error) {
       return ToolResult.err("Failed to navigate to entry", (error as Error).message);

--- a/packages/frontend/src/stores/agent/session/store.model.ts
+++ b/packages/frontend/src/stores/agent/session/store.model.ts
@@ -36,7 +36,7 @@ export function createInitialModel(): SessionModel {
     selectedCustomAgentId: undefined,
     mode: "focus",
     allowedWorkflowIds: undefined,
-    reasoningEffort: "medium",
+    reasoningEffort: "low",
   };
 }
 

--- a/packages/frontend/src/stores/agent/session/store.update.spec.ts
+++ b/packages/frontend/src/stores/agent/session/store.update.spec.ts
@@ -41,10 +41,10 @@ const testModel = {
 
 describe("session update", () => {
   describe("createInitialModel", () => {
-    it("sets default reasoning effort to medium", () => {
+    it("sets default reasoning effort to low", () => {
       const model = createInitialModel();
 
-      expect(model.reasoningEffort).toBe("medium");
+      expect(model.reasoningEffort).toBe("low");
     });
   });
 

--- a/packages/frontend/src/utils/ai.ts
+++ b/packages/frontend/src/utils/ai.ts
@@ -92,6 +92,8 @@ export function createModel(sdk: FrontendSDK, model: Model, options: CreateModel
 }
 
 const PREFERRED_AGENT_MODELS = [
+  "openrouter/openai/gpt-5.5",
+  "openai/gpt-5.5",
   "openrouter/anthropic/claude-sonnet-4.6",
   "openrouter/google/gemini-3.1-pro-preview-customtools",
   "anthropic/claude-sonnet-4-6",

--- a/packages/frontend/src/utils/caido.ts
+++ b/packages/frontend/src/utils/caido.ts
@@ -5,6 +5,21 @@ import { isPresent } from "./optional";
 
 import { type FrontendSDK } from "@/types";
 
+export const decodeBlob = (encoded: string): string => {
+  if (encoded === "") {
+    return "";
+  }
+
+  const binary = atob(encoded);
+
+  try {
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return binary;
+  }
+};
+
 export const resolveEditorView = (el: Element | undefined): EditorView | undefined => {
   if (!isPresent(el)) {
     return undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,8 +131,8 @@ importers:
         specifier: 0.57.0
         version: 0.57.0
       '@caido/sdk-frontend':
-        specifier: 0.57.1-beta.4
-        version: 0.57.1-beta.4(@ai-sdk/provider@3.0.8)(@codemirror/state@6.5.4)(@codemirror/view@6.39.16)(vue@3.5.29(typescript@5.5.4))
+        specifier: 0.56.3-beta.2
+        version: 0.56.3-beta.2(@ai-sdk/provider@3.0.8)(@codemirror/state@6.5.4)(@codemirror/view@6.39.16)(vue@3.5.29(typescript@5.5.4))
       '@codemirror/view':
         specifier: 6.39.16
         version: 6.39.16
@@ -222,6 +222,14 @@ packages:
 
   '@caido/sdk-backend@0.57.0':
     resolution: {integrity: sha512-GwPytq4g+lhrLXkwkAHOzp8CQuPEfU+zAC92o1HDZa0gkeDWwKB3j0zi9HgdF8dgyARY5MV3s67ebljGrC0ywQ==}
+
+  '@caido/sdk-frontend@0.56.3-beta.2':
+    resolution: {integrity: sha512-qSe9YDdhUlhWoOutJYFUAo22yEvGSJgahdkANIevGl016CJlDueydTeINshaFpH+bUaiflreXfCcs76eRIhvgg==}
+    peerDependencies:
+      '@ai-sdk/provider': ^3.0.1
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
+      vue: ^3.0.0
 
   '@caido/sdk-frontend@0.57.1-beta.4':
     resolution: {integrity: sha512-nfekgMRGr3cTcCbZOC4jDGime4H1jAcN3zAHvp1OUJLk+DUWX02Sefd3bqfSYk+cFHg7x+ByZAjv635mtzK7Qg==}
@@ -697,49 +705,41 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -825,79 +825,66 @@ packages:
     resolution: {integrity: sha512-Ob8YgT5kD/lSIYW2Rcngs5kNB/44Q2RzBSPz9brf2WEtcGR7/f/E9HeHn1wYaAwKBni+bdXEwgHvUd0x12lQSA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.58.0':
     resolution: {integrity: sha512-K+RI5oP1ceqoadvNt1FecL17Qtw/n9BgRSzxif3rTL2QlIu88ccvY+Y9nnHe/cmT5zbH9+bpiJuG1mGHRVwF4Q==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.58.0':
     resolution: {integrity: sha512-T+17JAsCKUjmbopcKepJjHWHXSjeW7O5PL7lEFaeQmiVyw4kkc5/lyYKzrv6ElWRX/MrEWfPiJWqbTvfIvjM1Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.58.0':
     resolution: {integrity: sha512-cCePktb9+6R9itIJdeCFF9txPU7pQeEHB5AbHu/MKsfH/k70ZtOeq1k4YAtBv9Z7mmKI5/wOLYjQ+B9QdxR6LA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.58.0':
     resolution: {integrity: sha512-iekUaLkfliAsDl4/xSdoCJ1gnnIXvoNz85C8U8+ZxknM5pBStfZjeXgB8lXobDQvvPRCN8FPmmuTtH+z95HTmg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.58.0':
     resolution: {integrity: sha512-68ofRgJNl/jYJbxFjCKE7IwhbfxOl1muPN4KbIqAIe32lm22KmU7E8OPvyy68HTNkI2iV/c8y2kSPSm2mW/Q9Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.58.0':
     resolution: {integrity: sha512-dpz8vT0i+JqUKuSNPCP5SYyIV2Lh0sNL1+FhM7eLC457d5B9/BC3kDPp5BBftMmTNsBarcPcoz5UGSsnCiw4XQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.58.0':
     resolution: {integrity: sha512-4gdkkf9UJ7tafnweBCR/mk4jf3Jfl0cKX9Np80t5i78kjIH0ZdezUv/JDI2VtruE5lunfACqftJ8dIMGN4oHew==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.58.0':
     resolution: {integrity: sha512-YFS4vPnOkDTD/JriUeeZurFYoJhPf9GQQEF/v4lltp3mVcBmnsAdjEWhr2cjUCZzZNzxCG0HZOvJU44UGHSdzw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.58.0':
     resolution: {integrity: sha512-x2xgZlFne+QVNKV8b4wwaCS8pwq3y14zedZ5DqLzjdRITvreBk//4Knbcvm7+lWmms9V9qFp60MtUd0/t/PXPw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.58.0':
     resolution: {integrity: sha512-jIhrujyn4UnWF8S+DHSkAkDEO3hLX0cjzxJZPLF80xFyzyUIYgSMRcYQ3+uqEoyDD2beGq7Dj7edi8OnJcS/hg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.58.0':
     resolution: {integrity: sha512-+410Srdoh78MKSJxTQ+hZ/Mx+ajd6RjjPwBPNd0R3J9FtL6ZA0GqiiyNjCO9In0IzZkCNrpGymSfn+kgyPQocg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.58.0':
     resolution: {integrity: sha512-ZjMyby5SICi227y1MTR3VYBpFTdZs823Rs/hpakufleBoufoOIB6jtm9FEoxn/cgO7l6PM2rCEl5Kre5vX0QrQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.58.0':
     resolution: {integrity: sha512-ds4iwfYkSQ0k1nb8LTcyXw//ToHOnNTJtceySpL3fa7tc/AsE+UpUFphW126A6fKBGJD5dhRvg8zw1rvoGFxmw==}
@@ -3216,6 +3203,13 @@ snapshots:
     dependencies:
       '@caido/quickjs-types': 0.26.0
       '@caido/sdk-shared': 0.2.2
+
+  '@caido/sdk-frontend@0.56.3-beta.2(@ai-sdk/provider@3.0.8)(@codemirror/state@6.5.4)(@codemirror/view@6.39.16)(vue@3.5.29(typescript@5.5.4))':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.16
+      vue: 3.5.29(typescript@5.5.4)
 
   '@caido/sdk-frontend@0.57.1-beta.4(@ai-sdk/provider@3.0.8)(@codemirror/state@6.5.4)(@codemirror/view@6.39.16)(vue@3.5.29(typescript@5.5.4))':
     dependencies:


### PR DESCRIPTION
- Downgrades `sdk-frontend` to `0.56.3-beta.2` (theres no 0.57.0 sdk stable or beta released)
- fixes missing base64 blob decode in `ReplayEntryNavigate`
- makes `gpt5.5@low` a default model for agent, it works great!
- bumps version